### PR TITLE
Fix inproper import of scipy.io.

### DIFF
--- a/cogdl/datasets/matlab_matrix.py
+++ b/cogdl/datasets/matlab_matrix.py
@@ -4,7 +4,7 @@ import os.path as osp
 from itertools import product
 
 import numpy as np
-import scipy
+import scipy.io
 import torch
 
 from cogdl.data import Data, Dataset, download_url


### PR DESCRIPTION
Bug:

I met the following exception when I ran the demo command provided in `README.md`:

```
Processing...
Traceback (most recent call last):
  File "scripts/train.py", line 75, in <module>
    results = [main(args) for args in variant_args_generator(args, variants)]
  File "scripts/train.py", line 75, in <listcomp>
    results = [main(args) for args in variant_args_generator(args, variants)]
  File "scripts/train.py", line 26, in main
    task = build_task(args)
  File "/home/augf/test/cogdl/cogdl/tasks/__init__.py", line 48, in build_task
    return TASK_REGISTRY[args.task](args)
  File "/home/augf/test/cogdl/cogdl/tasks/unsupervised_node_classification.py", line 42, in __init__
    dataset = build_dataset(args)
  File "/home/augf/test/cogdl/cogdl/datasets/__init__.py", line 58, in build_dataset
    return DATASET_REGISTRY[args.dataset]()
  File "/home/augf/test/cogdl/cogdl/datasets/matlab_matrix.py", line 87, in __init__
    super(WikipediaDataset, self).__init__(path, filename, url)
  File "/home/augf/test/cogdl/cogdl/datasets/matlab_matrix.py", line 26, in __init__
    super(MatlabMatrix, self).__init__(root)
  File "/home/augf/test/cogdl/cogdl/data/dataset.py", line 79, in __init__
    self._process()
  File "/home/augf/test/cogdl/cogdl/data/dataset.py", line 113, in _process
    self.process()
  File "/home/augf/test/cogdl/cogdl/datasets/matlab_matrix.py", line 49, in process
    smat = scipy.io.loadmat(path)
AttributeError: module 'scipy' has no attribute 'io'
```

Solution:

It is caused by only importing `scipy` in the beginning of the `matlab_matrix.py`. I fix the bug in this pull request by importing `scipy.io` instead.