### PR TITLE
[Proposal] Introduce style enforcement

### DIFF
--- a/.flake
+++ b/.flake
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401, W291
+max-line-length = 120
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3.6
+        args: [--line-length=120] # this should be in pyproject.toml not sure why its not picked up
+  -   repo: https://gitlab.com/pycqa/flake8
+      rev: 3.8.4
+      hooks:
+      - id: flake8
+        additional_dependencies: [flake8-typing-imports==1.9.0]
+        args: ['--config=.flake']

--- a/pyprojet.toml
+++ b/pyprojet.toml
@@ -1,0 +1,17 @@
+[tool.black]
+line-length = 120
+target-version = ['py36']
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''


### PR DESCRIPTION
From my experience it is important (if not vital) to keep code style consistent across the whole codebase. Consistency improves making assumptions about how things should work but also improves readability (and [as we know](https://www.python.org/dev/peps/pep-0020/) - readability counts). 

Currently, the repository has a mandatory black step on travis but this is something that happens in the background during CI and it seems that the black changes are not committed to the main branch (please correct me if I'm wrong here). Locally running black gives me `142 files would be reformatted, 27 files would be left unchanged.`. 

With this PR I would like to introduce enforcing a code style dictated (mostly) by [PEP](https://www.python.org/dev/peps/pep-0008/) (through [flake8](https://flake8.pycqa.org/en/latest/)) and [black](https://github.com/psf/black) with small modifications and hook to [pre-commit](https://pre-commit.com/). This combination offers a quite easy transition and allows developers not to think/remember about formatting their code according to the guidelines.

Small explanations:
**flake8** is [a great toolkit for checking your code base against coding style (PEP8), programming errors (like “library imported but unused” and “Undefined name”) and to check cyclomatic complexity](https://simpleisbetterthancomplex.com/packages/2016/08/05/flake8.html). 
**black** is a code formatter. In essence it modifies the *.py files to be consistent with the defined rules. In this setup it would do the formatting in the background when commit command is executed. 
**auto-commit** is a library that executes some code when the developer executes `git commit` command. For this change it means that auto-commit will trigger `black` and `flake8` commands. If any of those commands return something else than 0 ('all good') the person will not be able to commit their changes (It is still possible to commit without style checking by adding `--no-verify` to the command. ). 

After this PR is merged, each person who wants to commit to this repository would have to have `precommit` installed (possibly also flake8?).  As you might notice, I have not changed any *.py files yet, this is because the checker and autoformatter works lazily - only on the files that will actually be committed. This means that the person who touches the file will be responsible to format it to a correct form if autoformatter is not decisive enough. I am happy to demonstrate this on one of the files if needed. 

Example:
I have added one space in `tests\tasks\test_multiplex_link_prediction.py` file, added this file by `git add *.py` and executed `git commit -m"Test"` command. 

![image](https://user-images.githubusercontent.com/7461791/100388517-1f318c80-302b-11eb-9fc2-a239996aec8a.png)

Since there were failures, the code was not committed. Also, you can see that black modified the source code (`files were modified by this hook`). Now, it should be enough to manually fix flake8 errors (black ones were fixed automatically) and the commit should be good to go.
At the beginning, this might mean that there will be many false positives because as of now the code does not adhere to PEP8 very well, but because of laziness, we are guaranteed that the change is gradual. However, it is important to introduce consistency as early as possible - the more code there is to fix the worse the experience.

The flake8 and black configurations in this PR are purely my preference, I am happy to change those and/or have a philosophical discussion on whether this is a good configuration. In all projects that I am involved with I am using (almost) exactly this configuration. 
