### PR TITLE
Remove gtn model's dependency on torch_geometric

### DIFF
--- a/cogdl/models/nn/gtn.py
+++ b/cogdl/models/nn/gtn.py
@@ -1,0 +1,257 @@
+import math
+import numpy as np
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parameter import Parameter
+
+from torch_scatter import scatter_add
+import torch_sparse
+# from torch_geometric.utils.num_nodes import maybe_num_nodes
+# from torch_geometric.utils import dense_to_sparse, f1_score
+from sklearn.metrics import f1_score
+# from torch_geometric.utils import remove_self_loops, add_self_loops
+# from torch_geometric.nn import GCNConv
+
+from .. import BaseModel, register_model
+
+
+def remove_self_loops(edge_index, edge_attr = None):
+    r"""Removes every self-loop in the graph given by :attr:`edge_index`, so
+    that :math:`(i,i) \not\in \mathcal{E}` for every :math:`i \in \mathcal{V}`.
+
+    Args:
+        edge_index (LongTensor): The edge indices.
+        edge_attr (Tensor, optional): Edge weights or multi-dimensional
+            edge features. (default: :obj:`None`)
+
+    :rtype: (:class:`LongTensor`, :class:`Tensor`)
+
+    https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/utils/loop.html#remove_self_loops
+    """
+    mask = edge_index[0] != edge_index[1]
+    edge_index = edge_index[:, mask]
+    if edge_attr is None:
+        return edge_index, None
+    else:
+        return edge_index, edge_attr[mask]
+
+
+class GraphConvolution(nn.Module):
+    """
+    Simple GCN layer, similar to https://arxiv.org/abs/1609.02907
+    """
+
+    def __init__(self, in_features, out_features, bias=True):
+        super(GraphConvolution, self).__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = Parameter(torch.FloatTensor(in_features, out_features))
+        if bias:
+            self.bias = Parameter(torch.FloatTensor(out_features))
+        else:
+            self.register_parameter("bias", None)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        stdv = 1.0 / math.sqrt(self.weight.size(1))
+        self.weight.data.uniform_(-stdv, stdv)
+        if self.bias is not None:
+            self.bias.data.zero_()
+
+    def forward(self, input, edge_index, edge_attr=None):
+        if edge_attr is None:
+            edge_attr = torch.ones(edge_index.shape[1]).float().to(input.device)
+        adj = torch.sparse_coo_tensor(
+            edge_index,
+            edge_attr,
+            (input.shape[0], input.shape[0]),
+        ).to(input.device)
+        support = torch.mm(input, self.weight)
+        output = torch.spmm(adj, support)
+        if self.bias is not None:
+            return output + self.bias
+        else:
+            return output
+
+    def __repr__(self):
+        return self.__class__.__name__ + " (" + str(self.in_features) + " -> " + str(self.out_features) + ")"
+
+
+class GTConv(nn.Module):
+    def __init__(self, in_channels, out_channels, num_nodes):
+        super(GTConv, self).__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.weight = nn.Parameter(torch.Tensor(out_channels, in_channels))
+        self.bias = None
+        self.scale = nn.Parameter(torch.Tensor([0.1]), requires_grad=False)
+        self.num_nodes = num_nodes
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        nn.init.constant_(self.weight, 1)
+        if self.bias is not None:
+            fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in)
+            nn.init.uniform_(self.bias, -bound, bound)
+
+    def forward(self, A):
+        filter = F.softmax(self.weight, dim=1)
+        num_channels = filter.shape[0]
+        results = []
+        for i in range(num_channels):
+            for j, (edge_index, edge_value) in enumerate(A):
+                if j == 0:
+                    total_edge_index = edge_index
+                    total_edge_value = edge_value * filter[i][j]
+                else:
+                    total_edge_index = torch.cat((total_edge_index, edge_index), dim=1)
+                    total_edge_value = torch.cat((total_edge_value, edge_value * filter[i][j]))
+            index, value = torch_sparse.coalesce(
+                total_edge_index.detach(), total_edge_value, m=self.num_nodes, n=self.num_nodes
+            )
+            results.append((index, value))
+        return results
+
+
+class GTLayer(nn.Module):
+    def __init__(self, in_channels, out_channels, num_nodes, first=True):
+        super(GTLayer, self).__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.first = first
+        self.num_nodes = num_nodes
+        if self.first:
+            self.conv1 = GTConv(in_channels, out_channels, num_nodes)
+            self.conv2 = GTConv(in_channels, out_channels, num_nodes)
+        else:
+            self.conv1 = GTConv(in_channels, out_channels, num_nodes)
+
+    def forward(self, A, H_=None):
+        if self.first:
+            result_A = self.conv1(A)
+            result_B = self.conv2(A)
+            W = [(F.softmax(self.conv1.weight, dim=1)).detach(), (F.softmax(self.conv2.weight, dim=1)).detach()]
+        else:
+            result_A = H_
+            result_B = self.conv1(A)
+            W = [(F.softmax(self.conv1.weight, dim=1)).detach()]
+        H = []
+        for i in range(len(result_A)):
+            a_edge, a_value = result_A[i]
+            b_edge, b_value = result_B[i]
+
+            edges, values = torch_sparse.spspmm(
+                a_edge, a_value, b_edge, b_value, self.num_nodes, self.num_nodes, self.num_nodes
+            )
+            H.append((edges, values))
+        return H, W
+
+
+@register_model("unpyg-gtn")
+class GTN(BaseModel):
+    @staticmethod
+    def add_args(parser):
+        """Add model-specific arguments to the parser."""
+        # fmt: off
+        parser.add_argument("--num-features", type=int)
+        parser.add_argument("--num-classes", type=int)
+        parser.add_argument("--num-nodes", type=int)
+        parser.add_argument("--hidden-size", type=int, default=64)
+        parser.add_argument("--num-layers", type=int, default=2)
+        parser.add_argument("--num-edge", type=int, default=2)
+        parser.add_argument("--num-channels", type=int, default=2)
+        # fmt: on
+
+    @classmethod
+    def build_model_from_args(cls, args):
+        return cls(
+            args.num_edge,
+            args.num_channels,
+            args.num_features,
+            args.hidden_size,
+            args.num_classes,
+            args.num_nodes,
+            args.num_layers,
+        )
+
+    def __init__(self, num_edge, num_channels, w_in, w_out, num_class, num_nodes, num_layers):
+        super(GTN, self).__init__()
+        self.num_edge = num_edge
+        self.num_channels = num_channels
+        self.num_nodes = num_nodes
+        self.w_in = w_in
+        self.w_out = w_out
+        self.num_class = num_class
+        self.num_layers = num_layers
+        layers = []
+        for i in range(num_layers):
+            if i == 0:
+                layers.append(GTLayer(num_edge, num_channels, num_nodes, first=True))
+            else:
+                layers.append(GTLayer(num_edge, num_channels, num_nodes, first=False))
+        self.layers = nn.ModuleList(layers)
+        self.cross_entropy_loss = nn.CrossEntropyLoss()
+        self.gcn = GraphConvolution(in_features=self.w_in, out_features=w_out)
+        self.linear1 = nn.Linear(self.w_out * self.num_channels, self.w_out)
+        self.linear2 = nn.Linear(self.w_out, self.num_class)
+
+    def normalization(self, H):
+        norm_H = []
+        for i in range(self.num_channels):
+            edge, value = H[i]
+            edge, value = remove_self_loops(edge, value)
+            deg_row, deg_col = self.norm(edge.detach(), self.num_nodes, value.detach())
+            value = deg_col * value
+            norm_H.append((edge, value))
+        return norm_H
+
+    def norm(self, edge_index, num_nodes, edge_weight, improved=False, dtype=None):
+        with torch.no_grad():
+            if edge_weight is None:
+                edge_weight = torch.ones((edge_index.size(1),), dtype=dtype, device=edge_index.device)
+            edge_weight = edge_weight.view(-1)
+            assert edge_weight.size(0) == edge_index.size(1)
+            row, col = edge_index
+            deg = scatter_add(edge_weight, col, dim=0, dim_size=num_nodes)
+            deg_inv_sqrt = deg.pow(-1)
+            deg_inv_sqrt[deg_inv_sqrt == float("inf")] = 0
+
+        return deg_inv_sqrt[row], deg_inv_sqrt[col]
+
+    def forward(self, A, X, target_x, target):
+        Ws = []
+        for i in range(self.num_layers):
+            if i == 0:
+                H, W = self.layers[i](A)
+            else:
+                H = self.normalization(H)
+                H, W = self.layers[i](A, H)
+            Ws.append(W)
+        for i in range(self.num_channels):
+            if i == 0:
+                edge_index, edge_weight = H[i][0], H[i][1]
+                X_ = self.gcn(X, edge_index=edge_index.detach(), edge_attr=edge_weight)
+                X_ = F.relu(X_)
+            else:
+                edge_index, edge_weight = H[i][0], H[i][1]
+                X_ = torch.cat(
+                    (X_, F.relu(self.gcn(X, edge_index=edge_index.detach(), edge_attr=edge_weight))), dim=1
+                )
+        X_ = self.linear1(X_)
+        X_ = F.relu(X_)
+        # X_ = F.dropout(X_, p=0.5)
+        y = self.linear2(X_[target_x])
+        loss = self.cross_entropy_loss(y, target)
+        return loss, y, Ws
+
+    def loss(self, data):
+        loss, y, _ = self.forward(data.adj, data.x, data.train_node, data.train_target)
+        return loss
+
+    def evaluate(self, data, nodes, targets):
+        loss, y, _ = self.forward(data.adj, data.x, nodes, targets)
+        f1 = torch.mean(torch.tensor(f1_score(torch.argmax(y, dim=1), targets, labels = list(range(3)), average=None)))
+        return loss.item(), f1.item()

--- a/match.yml
+++ b/match.yml
@@ -157,6 +157,7 @@ heterogeneous_node_classification:
   - model:
     - gtn
     - han
+    - unpyg-gtn
     dataset:
     - gtn-dblp
     - gtn-acm

--- a/tests/tasks/test_heterogeneous_node_classification.py
+++ b/tests/tasks/test_heterogeneous_node_classification.py
@@ -32,6 +32,17 @@ def test_gtn_gtn_imdb():
     ret = task.train()
     assert ret["f1"] >= 0 and ret["f1"] <= 1
 
+def test_unpyg_gtn_gtn_imdb():
+    args = get_default_args()
+    args.task = "heterogeneous_node_classification"
+    args.dataset = "gtn-imdb"
+    args.model = "unpyg-gtn"
+    args.num_channels = 2
+    args.num_layers = 2
+    task = build_task(args)
+    ret = task.train()
+    assert ret["f1"] >= 0 and ret["f1"] <= 1
+
 
 def test_han_gtn_acm():
     args = get_default_args()
@@ -91,6 +102,7 @@ def test_han_han_dblp():
 
 if __name__ == "__main__":
     test_gtn_gtn_imdb()
+    test_unpyg_gtn_gtn_imdb()
     test_han_gtn_acm()
     test_han_gtn_dblp()
     test_han_han_imdb()


### PR DESCRIPTION
They get almost the same performance on the `heterogeneous_node_classification` task and `gtn-imdb` dataset.

my implement:
```
(master*%=) % python scripts/train.py --task heterogeneous_node_classification --dataset gtn-imdb --model unpyg-gtn --cpu --max-epoch=100
Using backend: pytorch
Namespace(cpu=True, dataset=['gtn-imdb'], device_id=[0], enhance=None, hidden_size=64, lr=0.01, max_epoch=100, model=['unpyg-gtn'], num_channels=2, num_classes=None, num_edge=2, num_features=None, num_layers=2, num_nodes=None, patience=100, save_dir='.', seed=[1], task='heterogeneous_node_classification', weight_decay=0.0005)
Epoch: 099, Train: 1.0000, Val: 0.6673: 100%|█| 100/100 [05:08<00:00,  3.08s/it]
Test f1 = 0.556902356902357
| Variant                   | f1            |
|---------------------------|---------------|
| ('gtn-imdb', 'unpyg-gtn') | 0.5569±0.0000 |
```

original (with pyg):
```
(master=) % python scripts/train.py --task heterogeneous_node_classification --dataset gtn-imdb --model gtn --cpu --max-epoch=100
Using backend: pytorch
Namespace(cpu=True, dataset=['gtn-imdb'], device_id=[0], enhance=None, hidden_size=64, lr=0.01, max_epoch=100, model=['gtn'], num_channels=2, num_classes=None, num_edge=2, num_features=None, num_layers=2, num_nodes=None, patience=100, save_dir='.', seed=[1], task='heterogeneous_node_classification', weight_decay=0.0005)
Epoch: 099, Train: 1.0000, Val: 0.6767: 100%|█| 100/100 [16:58<00:00, 10.18s/it]
Test f1 = 0.5622790455818176
| Variant             | f1            |
|---------------------|---------------|
| ('gtn-imdb', 'gtn') | 0.5623±0.0000 |
```