### PR TITLE
Add auc evaluation metric 

### DIFF
--- a/cogdl/experiments.py
+++ b/cogdl/experiments.py
@@ -30,7 +30,7 @@ class AutoML(object):
 
     def __init__(self, args):
         self.search_space = args.search_space
-        self.metric = args.metric if hasattr(args, "metric") else None
+        self.metric = args.metric if hasattr(args, "metric") else "auto"
         self.n_trials = args.n_trials if hasattr(args, "n_trials") else 3
         self.best_value = None
         self.best_params = None
@@ -46,6 +46,7 @@ class AutoML(object):
         result_list = list(result_dict.values())[0]
         item = result_list[0]
         key = self.metric
+        print(key)
         if key is None:
             for _key in item.keys():
                 if "Val" in _key or "val" in _key:
@@ -210,6 +211,7 @@ def train(args):  # noqa: C901
         nstage=args.nstage,
         actnn=args.actnn,
         fp16=args.fp16,
+        metric=args.metric if hasattr(args, "metric") else "acc",
     )
 
     # Go!!!

--- a/cogdl/trainer/trainer.py
+++ b/cogdl/trainer/trainer.py
@@ -19,8 +19,7 @@ from cogdl.trainer.embed_trainer import EmbeddingTrainer
 from cogdl.trainer.controller import DataController
 from cogdl.loggers import build_logger
 from cogdl.data import Graph
-from cogdl.utils.grb_utils import adj_preprocess, updateGraph, adj_to_tensor
-
+from cogdl.utils.evaluator import setup_evaluator
 
 def move_to_device(batch, device):
     if isinstance(batch, list) or isinstance(batch, tuple):
@@ -75,10 +74,10 @@ class Trainer(object):
         actnn: bool = False,
         fp16: bool = False,
         rp_ratio: int = 1,
-        attack=None,
-        attack_mode="injection",
+        metric: str =  "auto",
     ):
         self.epochs = epochs
+        self.metric = metric
         self.nstage = nstage
         self.patience = patience
         self.early_stopping = early_stopping
@@ -128,8 +127,6 @@ class Trainer(object):
         self.eval_data_back_to_cpu = False
 
         self.fp16 = fp16
-        self.attack = attack
-        self.attack_mode = attack_mode
 
         if actnn:
             try:
@@ -180,7 +177,7 @@ class Trainer(object):
         # set default loss_fn and evaluator for model_wrapper
         # mainly for in-cogdl setting
         model_w.default_loss_fn = dataset_w.get_default_loss_fn()
-        model_w.default_evaluator = dataset_w.get_default_evaluator()
+        model_w.default_evaluator = setup_evaluator(self.metric)
         model_w.set_evaluation_metric()
 
         if self.resume_training:
@@ -326,11 +323,6 @@ class Trainer(object):
 
             self.logger.start()
             print_str_dict = dict()
-            if self.attack is not None:
-                graph = dataset_w.dataset.data
-                graph_backup = copy.deepcopy(graph)
-                graph0 = copy.deepcopy(graph)
-                num_train = torch.sum(graph.train_mask).item()
             for epoch in epoch_iter:
                 for hook in self.pre_epoch_hooks:
                     hook(self)
@@ -343,23 +335,6 @@ class Trainer(object):
                     train_dataset.shuffle()
                 training_loss = self.train_step(model_w, train_loader, optimizers, lr_schedulers, rank, scaler)
 
-                if self.attack is not None:
-                    if self.attack_mode == "injection":
-                        graph0.test_mask = graph0.train_mask
-                    else:
-                        graph0.test_mask[torch.where(graph0.train_mask)[0].multinomial(int(num_train * 0.01))] = True
-                    graph_attack = self.attack.attack(model=model_w.model, graph=graph0, adj_norm_func=None)  # todo
-                    adj_attack = graph_attack.to_scipy_csr()
-                    features_attack = graph_attack.x
-                    adj_train = adj_preprocess(adj=adj_attack, adj_norm_func=None, device=rank)  # todo
-                    n_inject = graph_attack.num_nodes - graph.num_nodes
-                    updateGraph(graph, adj_train, features_attack)
-                    graph.edge_weight = torch.ones(graph.num_edges, device=rank)
-                    graph.train_mask = torch.cat((graph.train_mask, torch.zeros(n_inject, dtype=bool, device=rank)), 0)
-                    graph.val_mask = torch.cat((graph.val_mask, torch.zeros(n_inject, dtype=bool, device=rank)), 0)
-                    graph.test_mask = torch.cat((graph.test_mask, torch.zeros(n_inject, dtype=bool, device=rank)), 0)
-                    graph.y = torch.cat((graph.y, torch.zeros(n_inject, device=rank)), 0)
-                    graph.grb_adj = adj_to_tensor(adj_train).to(rank)
                 print_str_dict["Epoch"] = epoch
                 print_str_dict["train_loss"] = training_loss
 
@@ -400,8 +375,6 @@ class Trainer(object):
 
             if best_model_w is None:
                 best_model_w = copy.deepcopy(model_w)
-            if self.attack is not None:
-                dataset_w.dataset.data = graph_backup
 
         if self.distributed_training:
             if rank == 0:

--- a/cogdl/wrappers/model_wrapper/base_model_wrapper.py
+++ b/cogdl/wrappers/model_wrapper/base_model_wrapper.py
@@ -2,7 +2,7 @@ from typing import Union, Callable
 from abc import abstractmethod
 import torch
 from cogdl.wrappers.tools.wrapper_utils import merge_batch_indexes
-from cogdl.utils.evaluator import setup_evaluator, Accuracy, MultiLabelMicroF1
+from cogdl.utils.evaluator import setup_evaluator, Accuracy, MultiLabelMicroF1,AUC
 
 
 class ModelWrapper(torch.nn.Module):
@@ -51,7 +51,8 @@ class ModelWrapper(torch.nn.Module):
                 else:
                     metric = "accuracy"
                     self._evaluator_metric = "acc"
-
+            if metric == "auc":
+                    self._evaluator_metric = "auc"
             self._evaluator = setup_evaluator(metric)
             # self._evaluator_metric = metric
         return self._evaluator(pred, labels)
@@ -153,6 +154,8 @@ class ModelWrapper(torch.nn.Module):
             self._evaluator_metric = "micro_f1"
         elif isinstance(self._evaluator, Accuracy):
             self._evaluator_metric = "acc"
+        elif isinstance(self._evaluator, AUC):
+            self._evaluator_metric = "auc"
         else:
             evaluation_metric = self.set_early_stopping()
             if not isinstance(evaluation_metric, str):


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.-->
Add auc evaluation metric in cogdl, now you can call metric in experiment() to choose accuracy or auc or f1 evaluation methods.
Like:
experiment(dataset="cora", model="gcn", seed=[1, 2], search_space=search_space, metric="auc")
python scripts/train.py --dataset cora citeseer --model gcn gat --metric auc

